### PR TITLE
feat: expand supported issue reference formats

### DIFF
--- a/pkg/gitlog/gitlog.go
+++ b/pkg/gitlog/gitlog.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	lineRegex = regexp.MustCompile(`(?im)^\s*(closes?|related|relates|merges?|back\s?ports?)\s+.*$`)
-	idRegex   = regexp.MustCompile(`#(\d+)`)
+	lineRegex = regexp.MustCompile(`(?im)^\s*(closes?|related|relates|merges?|back\s?ports?|resolved|resolves)\s+.*$`)
+	idRegex   = regexp.MustCompile(`(#|(https?\:\/\/(www\.)?github\.com\/)?camunda\/(camunda|zeebe)(\/|#))(\d+)`)
 )
 
 func GetHistory(path, start, end string) string {
@@ -44,9 +44,9 @@ func ExtractIssueIds(message string) []int {
 
 	for _, line := range lineRegex.FindAllString(message, -1) {
 		for _, match := range idRegex.FindAllStringSubmatch(line, -1) {
-			issueId, err := strconv.Atoi(match[1])
+			issueId, err := strconv.Atoi(match[6])
 			if err != nil {
-				log.Fatalln("Cannot convert issue id", match[1], err)
+				log.Fatalln("Cannot convert issue id", match[6], err)
 			}
 
 			if !seen[issueId] {


### PR DESCRIPTION
Expands the supported issue reference formats from commit messages. The following are supported and detected:

* #<ID>
* https://www.github.com/camunda/camunda/<ID>
* https://www.github.com/camunda/zeebe/<ID>
* http://www.github.com/camunda/camunda/<ID>
* http://www.github.com/camunda/zeebe/<ID>
* https://github.com/camunda/camunda/<ID>
* https://github.com/camunda/zeebe/<ID>
* http://github.com/camunda/camunda/<ID>
* http://github.com/camunda/zeebe/<ID>
* camunda/camunda/<ID>
* camunda/zeebe/<ID>
* camunda/camunda#<ID>
* camunda/zeebe#<ID>